### PR TITLE
🩺 Provide Helm Chart for Keycloak 2.26 🩺

### DIFF
--- a/rhbk/.helmignore
+++ b/rhbk/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/rhbk/Chart.yaml
+++ b/rhbk/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: rhbk
+description: A Helm chart for Kubernetes to deploy Red Hat Build of Keycloak
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "2.26.X"
+
+maintainers:
+- name: alopezme

--- a/rhbk/templates/_helpers.tpl
+++ b/rhbk/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rhbk.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rhbk.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rhbk.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rhbk.labels" -}}
+helm.sh/chart: {{ include "rhbk.chart" . }}
+{{ include "rhbk.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rhbk.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rhbk.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rhbk.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rhbk.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/rhbk/templates/keycloak.yaml
+++ b/rhbk/templates/keycloak.yaml
@@ -10,6 +10,9 @@ spec:
   bootstrapAdmin:
     user:
       secret: keycloak-admin
+{{- if .Values.postgresql.enabled }}
+  # Database configuration - requires postgresql.enabled: true
+  # When disabled, Keycloak uses embedded H2 database (ephemeral, suitable for demos)
   db:
     vendor: postgres
     host: {{ .Values.postgresql.name }}
@@ -19,6 +22,7 @@ spec:
     passwordSecret:
       name: {{ .Values.postgresql.name }}-credentials
       key: password
+{{- end }}
   http:
     tlsSecret: keycloak-tls
     # https://www.keycloak.org/operator/advanced-configuration#_parameterizing_service_labels_and_annotations

--- a/rhbk/templates/keycloak.yaml
+++ b/rhbk/templates/keycloak.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: keycloak
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  instances: 1
+  bootstrapAdmin:
+    user:
+      secret: keycloak-admin
+  db:
+    vendor: postgres
+    host: {{ .Values.postgresql.name }}
+    usernameSecret:
+      name: {{ .Values.postgresql.name }}-credentials
+      key: username
+    passwordSecret:
+      name: {{ .Values.postgresql.name }}-credentials
+      key: password
+  http:
+    tlsSecret: keycloak-tls
+    # https://www.keycloak.org/operator/advanced-configuration#_parameterizing_service_labels_and_annotations
+    # annotations:
+    #   service.beta.openshift.io/serving-cert-secret-name: keycloak-tls
+  # hostname:
+  #   hostname: test.keycloak.org
+  ingress:
+    annotations:
+      route.openshift.io/destination-ca-certificate-secret: keycloak-tls
+      route.openshift.io/termination: reencrypt
+    className: openshift-default
+  proxy:
+    headers: xforwarded # double check your reverse proxy sets and overwrites the X-Forwarded-* headers
+{{- if .Values.keycloak.resources }}
+  resources:
+{{- toYaml .Values.keycloak.resources | nindent 4 }}
+{{- end }}
+{{- if .Values.keycloak.tracing }}
+  tracing:
+    enabled: false
+  additionalOptions:
+    {{ if .Values.keycloak.logging }}
+    - name: log-console-output
+      value: {{ .Values.keycloak.logging.logConsoleOutput | default "default" }}
+    {{ end }}
+    {{ if .Values.keycloak.metrics.enabled }}
+    - name: metrics-enabled
+      value: 'true'
+      {{ if .Values.keycloak.metrics.eventMetricsUserEnabled }}
+    - name: event-metrics-user-enabled
+      value: 'true'
+      {{ end }}
+    {{ end }}
+{{- end }}

--- a/rhbk/templates/keycloakrealmimport.yaml
+++ b/rhbk/templates/keycloakrealmimport.yaml
@@ -1,0 +1,95 @@
+---
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: pbrealm
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  keycloakCRName: keycloak
+  realm:
+    id: "pbrealm"
+    realm: "pbrealm"
+    displayName: "Pet Battle Single Sign On Realm"
+    enabled: true
+    loginWithEmailAllowed: false
+    registrationAllowed: true
+    registrationEmailAsUsername: false
+    rememberMe: true
+    sslRequired: "external"
+    clients:
+      - name: pbserver
+        clientId: pbserver
+        secret: {{ uuidv4 | quote }}
+        bearerOnly: true
+        protocol: openid-connect
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        directAccessGrantsEnabled: true
+        surrogateAuthRequired: false
+        enabled: true
+        clientAuthenticatorType: "client-secret"
+        consentRequired: false
+        implicitFlowEnabled: false
+        authorizationServicesEnabled: false
+        publicClient: false
+        frontchannelLogout: false
+        fullScopeAllowed: true
+        nodeReRegistrationTimeout: -1
+      - name: pbclient
+        clientId: pbclient
+        bearerOnly: false
+        protocol: openid-connect
+        publicClient: true
+        redirectUris:
+          - "https://{{ .Values.pet_battle_uri_name }}-{{ .Release.Namespace }}.{{ .Values.app_domain }}/*"
+          - "http://localhost:4200/*"
+        attributes:
+          post.logout.redirect.uris: "https://{{ .Values.pet_battle_uri_name }}-{{ .Release.Namespace }}.{{ .Values.app_domain }}/*,http://localhost:4200/*"
+        webOrigins:
+          - "*"
+        standardFlowEnabled: true
+        serviceAccountsEnabled: true
+        directAccessGrantsEnabled: true
+        surrogateAuthRequired: false
+        enabled: true
+        clientAuthenticatorType: "client-secret"
+        consentRequired: false
+        implicitFlowEnabled: false
+        frontchannelLogout: false
+        fullScopeAllowed: true
+        nodeReRegistrationTimeout: -1
+    users:
+      - username: "pbadmin"
+        firstName: "pbadmin"
+        lastName: "pbadmin"
+        email: "pbadmin@petbattle.com"
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "password"
+        realmRoles:
+          - "pbtest"
+          - "pbadmin"
+          - "pbplayer"
+          - "pbviewer"
+        clientRoles:
+          account:
+            - "manage-account"
+            - "view-profile"
+          realm-management:
+            - "manage-users"
+            - "view-users"
+            - "query-users"
+            - "create-client"
+      - username: "myuser"
+        firstName: "John"
+        lastName: "Doe"
+        email: "myuser@petbattle.com"
+        enabled: true
+        credentials:
+          - type: "password"
+            value: "password"
+        realmRoles:
+          - "pbplayer"
+          - "pbviewer"

--- a/rhbk/templates/operator/og-keycloak.yaml
+++ b/rhbk/templates/operator/og-keycloak.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.operator.enabled }}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: keycloak
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  upgradeStrategy: Default
+  targetNamespaces:
+    - {{ .Release.Namespace }}
+{{- end }}

--- a/rhbk/templates/operator/sub-keycloak.yaml
+++ b/rhbk/templates/operator/sub-keycloak.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.operator.enabled }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: keycloak
+  annotations:
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  channel: {{ .Values.operator.channel }}
+  installPlanApproval: {{ .Values.operator.installPlanApproval }}
+  name: rhbk-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+{{- end }}

--- a/rhbk/templates/postgresql/pvc-postgresql-db.yaml
+++ b/rhbk/templates/postgresql/pvc-postgresql-db.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.postgresql.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.postgresql.name }}-data
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+{{- end }}

--- a/rhbk/templates/postgresql/secret-postgresql-db-credentials.yaml
+++ b/rhbk/templates/postgresql/secret-postgresql-db-credentials.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.postgresql.enabled }}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Values.postgresql.name }}-credentials
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+stringData:
+  username: testuser
+  password: testpassword
+  database: keycloak
+type: Opaque
+{{- end }}

--- a/rhbk/templates/postgresql/sts-postgresql-db.yaml
+++ b/rhbk/templates/postgresql/sts-postgresql-db.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.postgresql.enabled }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Values.postgresql.name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  serviceName: {{ .Values.postgresql.name }}
+  selector:
+    matchLabels:
+      app: {{ .Values.postgresql.name }}
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.postgresql.name }}
+    spec:
+      containers:
+        - name: {{ .Values.postgresql.name }}
+          image: {{ .Values.postgresql.image.name }}:{{ .Values.postgresql.image.tag }}
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.name }}-credentials
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.name }}-credentials
+                  key: password
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.name }}-credentials
+                  key: database
+            - name: PGDATA
+              value: /data/pgdata
+          {{- if .Values.postgresql.ssl }}
+            - name: POSTGRES_INITDB_ARGS
+              value: -c ssl=on -c ssl_cert_file=/etc/ssl/certs/tls.crt -c ssl_key_file=/etc/ssl/certs/tls.key
+          {{- end }}
+          volumeMounts:
+            - mountPath: /data
+              name: data-volume
+          {{- if .Values.postgresql.ssl }}
+            - mountPath: /etc/ssl/certs
+              name: ssl-volume
+              readOnly: true
+          {{- end }}
+      volumes:
+        - name: data-volume
+          # emptyDir: {}
+          persistentVolumeClaim:
+            claimName: {{ .Values.postgresql.name }}-data
+      {{- if .Values.postgresql.ssl }}
+        - name: ssl-volume
+          secret:
+            secretName: {{ .Values.postgresql.name }}-tls
+            defaultMode: 0440
+      {{- end }}
+{{- end }}

--- a/rhbk/templates/postgresql/svc-postgresql-db.yaml
+++ b/rhbk/templates/postgresql/svc-postgresql-db.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgresql.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.postgresql.name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+    {{- if .Values.postgresql.ssl }}
+    service.beta.openshift.io/serving-cert-secret-name: {{ .Values.postgresql.name }}-tls
+    {{- end }}
+spec:
+  selector:
+    app: {{ .Values.postgresql.name }}
+  type: LoadBalancer
+  ports:
+  - port: 5432
+    targetPort: 5432
+{{- end }}

--- a/rhbk/templates/secret-keycloak-admin.yaml
+++ b/rhbk/templates/secret-keycloak-admin.yaml
@@ -1,0 +1,9 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: keycloak-admin
+stringData:
+  username: {{ .Values.keycloak.bootstrapAdmin.username }}
+  password: {{ .Values.keycloak.bootstrapAdmin.password }}
+type: Opaque

--- a/rhbk/templates/servicemonitor-keycloak.yaml
+++ b/rhbk/templates/servicemonitor-keycloak.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.keycloak.metrics.enabled }}
+---
+# https://www.keycloak.org/operator/advanced-configuration#_servicemonitor
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: keycloak
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: management
+    scheme: https
+    scrapeTimeout: 10s
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app: keycloak
+      app.kubernetes.io/instance: keycloak
+      app.kubernetes.io/managed-by: keycloak-operator
+  scrapeProtocols:
+    - OpenMetricsText1.0.0
+{{- end }}

--- a/rhbk/templates/svc-keycloak-service-trusted.yaml
+++ b/rhbk/templates/svc-keycloak-service-trusted.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: keycloak-tls
+  labels:
+    app: keycloak
+  name: keycloak-service-trusted
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+    - name: https
+      port: 8443
+  selector:
+    app: keycloak
+    app.kubernetes.io/instance: keycloak

--- a/rhbk/values.yaml
+++ b/rhbk/values.yaml
@@ -1,0 +1,43 @@
+# Default values for rhbk.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# pet-battle redirect uri name
+pet_battle_uri_name: pet-battle
+
+# override in argo
+# --set global.clusterDomain=$(oc get dns.config/cluster -o jsonpath='apps.{.spec.baseDomain}')
+app_domain: example.com
+
+operator:
+  enabled: true
+  channel: stable-v26.2
+  installPlanApproval: Automatic
+
+keycloak:
+  bootstrapAdmin:
+    username: admin
+    password: admin
+  # logging:
+  #   # Set the log output to JSON or default (plain) unstructured logging
+  #   logConsoleOutput: json
+  # https://www.keycloak.org/high-availability/multi-cluster/deploy-keycloak-kubernetes
+  metrics:
+    enabled: true
+    eventMetricsUserEnabled: true
+    grafanaDashboardsEnabled: false
+  resources:
+    requests:
+      cpu: 300m
+      memory: 700Mi
+    limits:
+      cpu: '2'
+      memory: 2Gi
+
+postgresql:
+  enabled: true
+  name: postgresql-db
+  ssl: true
+  image:
+    name: docker.io/library/postgres
+    tag: 17

--- a/rhbk/values.yaml
+++ b/rhbk/values.yaml
@@ -35,7 +35,7 @@ keycloak:
       memory: 2Gi
 
 postgresql:
-  enabled: true
+  enabled: false
   name: postgresql-db
   ssl: true
   image:


### PR DESCRIPTION
This PR provides an initial version of the upgrade from Keycloak old operator to the newest operator implementation provided by Red Hat.

This PR provides a separate chart from the keycloak one for better compatibility with old versions. This new chart provides:

- Keycloak with / without persistence.
- All based on the supported operator.
- Metrics and tracing for better debugging.
- Preconfigured Keycloak Realm with all the configuration that Pet Battle needs.
- This Helm chart provides the latest version of Keycloak.